### PR TITLE
Fixed: MemoryError decompressing large files

### DIFF
--- a/canvas_data/api.py
+++ b/canvas_data/api.py
@@ -252,11 +252,12 @@ class CanvasDataAPI(object):
                 # gunzip each file and write the data to the output file
                 for infilename in files:
                     with gzip.open(infilename, 'rb') as infile:
-                        try:
-                            outfile.write(infile.read())
-                        except IOError:
-                            msg = 'Error preparing data for table {}. Input file: {}  Output file: {}'.format(table_name, infilename, outfilename)
-                            raise CanvasDataAPIError(msg)
+                        for line in infile:
+                            try:
+                                outfile.write(line)
+                            except IOError:
+                                msg = 'Error preparing data for table {}. Input file: {}  Output file: {}'.format(table_name, infilename, outfilename)
+                                raise CanvasDataAPIError(msg)
 
             return outfilename
 


### PR DESCRIPTION
Using ```infile.read()``` causes a MemoryError with large files. Reading line-by-line buffers the read to prevent the error.