### PR TITLE
yaml.load obsolete change to yaml.safe_load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist
 data
 downloads
 MANIFEST
+.idea

--- a/canvas_data/scripts/canvasdata.py
+++ b/canvas_data/scripts/canvasdata.py
@@ -33,7 +33,7 @@ def cli(ctx, config, api_key, api_secret):
     is available at: canvas-data COMMAND --help"""
     # if a config file was specified, read settings from that
     if config:
-        ctx.obj = yaml.load(config)
+        ctx.obj = yaml.safe_load(config)
     else:
         ctx.obj = {}
 


### PR DESCRIPTION
The yaml.load method from PyYAML has been obsoleted and is now giving errors with latest Python3.10 updates on Ubuntu Linux. 

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Updated the canvasdata.py script to utilize yaml.safe-load per recommendation from documentation. 